### PR TITLE
Relax `send()` method typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tepper",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tepper",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Modern library for testing HTTP servers",
   "main": "dist/tepper.js",
   "engines": {
@@ -8,8 +8,10 @@
   },
   "homepage": "https://github.com/DanielRamosAcosta/tepper",
   "repository": "https://github.com/DanielRamosAcosta/tepper",
+  "author": "Daniel Ramos <danielramosacosta@hotmail.com>",
   "contributors": [
-    "Daniel Ramos <danielramosacosta@hotmail.com>"
+    "Daniel Ramos <danielramosacosta@hotmail.com>",
+    "Aitor Alonso <aitor@aalonso.dev>"
   ],
   "license": "MIT",
   "scripts": {

--- a/src/TepperBuilder.ts
+++ b/src/TepperBuilder.ts
@@ -1,9 +1,9 @@
+import { ParsedUrlQueryInput } from "querystring"
+import { BaseUrlServerOrExpress } from "./BaseUrlServerOrExpress"
+import { DebugOptions } from "./DebugOptions"
 import { TepperConfig } from "./TepperConfig"
 import { TepperResult } from "./TepperResult"
 import { TepperRunner } from "./TepperRunner"
-import { BaseUrlServerOrExpress } from "./BaseUrlServerOrExpress"
-import { ParsedUrlQueryInput } from "querystring"
-import { DebugOptions } from "./DebugOptions"
 export class TepperBuilder {
   public constructor(
     private readonly baseUrlServerOrExpress: BaseUrlServerOrExpress,
@@ -50,7 +50,7 @@ export class TepperBuilder {
     })
   }
 
-  public send(body: Record<string, unknown> | Array<unknown>) {
+  public send(body: string | object) {
     return new TepperBuilder(this.baseUrlServerOrExpress, {
       ...this.config,
       body,

--- a/src/TepperConfig.ts
+++ b/src/TepperConfig.ts
@@ -4,7 +4,7 @@ import { DebugOptions } from "./DebugOptions"
 export type TepperConfig = {
   readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
   readonly path: string
-  readonly body: Record<string, unknown> | Array<unknown> | null
+  readonly body: string | object | null
   readonly query: ParsedUrlQueryInput | null
   readonly redirects: number
   readonly expectedStatus: number | null


### PR DESCRIPTION
This PR resolves #62 

I have already run `npm version` to bump version to `0.3.4`, but I suppose you @DanielRamosAcosta must run `npm publish` 