### PR TITLE
Feat/add custom headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tepper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Modern library for testing HTTP servers",
   "main": "dist/tepper.js",
   "engines": {

--- a/src/TepperBuilder.ts
+++ b/src/TepperBuilder.ts
@@ -93,6 +93,13 @@ export class TepperBuilder {
     })
   }
 
+  public withHeaders(headers: Record<string, string>) {
+    return new TepperBuilder(this.baseUrlServerOrExpress, {
+      ...this.config,
+      customHeaders: headers,
+    })
+  }
+
   public debug({ body = true }: Partial<DebugOptions> = {}) {
     return new TepperBuilder(this.baseUrlServerOrExpress, {
       ...this.config,

--- a/src/TepperConfig.ts
+++ b/src/TepperConfig.ts
@@ -17,4 +17,5 @@ export type TepperConfig = {
   readonly timeout: number | null
   readonly jwt: string | null
   readonly debug: Partial<DebugOptions> | null
+  readonly customHeaders: Record<string, string>
 }

--- a/src/TepperRunner.ts
+++ b/src/TepperRunner.ts
@@ -75,6 +75,7 @@ export class TepperRunner {
       headers: {
         ...headers,
         ...(config.jwt ? { Authorization: `Bearer ${config.jwt}` } : {}),
+        ...config.customHeaders,
       },
       redirect: "manual",
       ...(config.timeout ? { timeout: config.timeout } : {}),

--- a/src/tepper.ts
+++ b/src/tepper.ts
@@ -14,5 +14,6 @@ export default function tepper(baseUrlExpressOrServer: BaseUrlServerOrExpress) {
     expectedBody: null,
     expectedStatus: null,
     debug: null,
+    customHeaders: {},
   })
 }

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -1,185 +1,21 @@
 import express from "express"
-import multer from "multer"
-import { createReadStream } from "fs"
 import tepper from "../src/tepper"
 
-describe("forms", () => {
-  it("supports sending a single file with fs.createReadStream", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post(
-      "/profile",
-      upload.single("document"),
-      (req, res) => {
-        const { file } = req
-        if (file) {
-          res.send({
-            document: {
-              content: file.buffer.toString("base64"),
-              filename: file.originalname,
-              mimetype: file.mimetype,
-            },
-            ...req.body,
-          })
-        }
-      },
-    )
+describe("headers", () => {
+  it("supports sending custom headers", async () => {
+    const CUSTOM_HEADER = "X-Custom-Header"
+    const CUSTOM_HEADER_VALUE = "custom-header-value"
+    const app = express().get("/", (req, res) => {
+      res.send(req.headers[CUSTOM_HEADER.toLowerCase()])
+    })
 
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        name: "Peter",
-        document: createReadStream("./test/fixtures/1.txt"),
+    const { text } = await tepper(app)
+      .get("/")
+      .withHeaders({
+        [CUSTOM_HEADER]: CUSTOM_HEADER_VALUE,
       })
       .run()
 
-    expect(body).toEqual({
-      name: "Peter",
-      document: {
-        content: "MQo=",
-        filename: "1.txt",
-        mimetype: "text/plain",
-      },
-    })
-  })
-
-  it("supports sending from a path", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post(
-      "/profile",
-      upload.single("document"),
-      (req, res) => {
-        const { file } = req
-        if (file) {
-          res.send({
-            document: {
-              content: file.buffer.toString("base64"),
-              filename: file.originalname,
-              mimetype: file.mimetype,
-            },
-            ...req.body,
-          })
-        }
-      },
-    )
-
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        name: "Peter",
-        document: createReadStream("./test/fixtures/1.txt"),
-      })
-      .run()
-
-    expect(body).toEqual({
-      name: "Peter",
-      document: {
-        content: "MQo=",
-        filename: "1.txt",
-        mimetype: "text/plain",
-      },
-    })
-  })
-
-  it("supports sending a an array of files in a field", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post(
-      "/profile",
-      upload.array("documents"),
-      (req, res) => {
-        const files = req.files
-        if (Array.isArray(files)) {
-          res.send({
-            documents: files.map((file) => file.buffer.toString("base64")),
-            ...req.body,
-          })
-        }
-      },
-    )
-
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        name: "Peter",
-        documents: [
-          createReadStream("./test/fixtures/1.txt"),
-          createReadStream("./test/fixtures/2.txt"),
-          createReadStream("./test/fixtures/3.txt"),
-        ],
-      })
-      .run()
-
-    expect(body).toEqual({
-      name: "Peter",
-      documents: ["MQo=", "Mgo=", "Mwo="],
-    })
-  })
-
-  it("supports nested fields", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post("/profile", upload.none(), (req, res) => {
-      res.send({
-        ...req.body,
-      })
-    })
-
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        name: "Peter",
-        paymentInfo: {
-          clientId: "0x12345",
-          amount: 10,
-        },
-      })
-      .run()
-
-    expect(body).toEqual({
-      name: "Peter",
-      paymentInfo: {
-        clientId: "0x12345",
-        amount: "10",
-      },
-    })
-  })
-
-  it("skips undefined values", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post("/profile", upload.none(), (req, res) => {
-      res.send({
-        ...req.body,
-      })
-    })
-
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        name: "Peter",
-        paymentInfo: undefined,
-      })
-      .run()
-
-    expect(body).toEqual({
-      name: "Peter",
-    })
-  })
-
-  it("supports sending arrays", async () => {
-    const upload = multer({ storage: multer.memoryStorage() })
-    const app = express().post("/profile", upload.none(), (req, res) => {
-      res.send({
-        ...req.body,
-      })
-    })
-
-    const { body } = await tepper(app)
-      .post("/profile")
-      .sendForm({
-        friends: ["friend1", "friend2"],
-      })
-      .run()
-
-    expect(body).toEqual({
-      friends: ["friend1", "friend2"],
-    })
+    expect(text).toEqual(CUSTOM_HEADER_VALUE)
   })
 })

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -1,0 +1,185 @@
+import express from "express"
+import multer from "multer"
+import { createReadStream } from "fs"
+import tepper from "../src/tepper"
+
+describe("forms", () => {
+  it("supports sending a single file with fs.createReadStream", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post(
+      "/profile",
+      upload.single("document"),
+      (req, res) => {
+        const { file } = req
+        if (file) {
+          res.send({
+            document: {
+              content: file.buffer.toString("base64"),
+              filename: file.originalname,
+              mimetype: file.mimetype,
+            },
+            ...req.body,
+          })
+        }
+      },
+    )
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        name: "Peter",
+        document: createReadStream("./test/fixtures/1.txt"),
+      })
+      .run()
+
+    expect(body).toEqual({
+      name: "Peter",
+      document: {
+        content: "MQo=",
+        filename: "1.txt",
+        mimetype: "text/plain",
+      },
+    })
+  })
+
+  it("supports sending from a path", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post(
+      "/profile",
+      upload.single("document"),
+      (req, res) => {
+        const { file } = req
+        if (file) {
+          res.send({
+            document: {
+              content: file.buffer.toString("base64"),
+              filename: file.originalname,
+              mimetype: file.mimetype,
+            },
+            ...req.body,
+          })
+        }
+      },
+    )
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        name: "Peter",
+        document: createReadStream("./test/fixtures/1.txt"),
+      })
+      .run()
+
+    expect(body).toEqual({
+      name: "Peter",
+      document: {
+        content: "MQo=",
+        filename: "1.txt",
+        mimetype: "text/plain",
+      },
+    })
+  })
+
+  it("supports sending a an array of files in a field", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post(
+      "/profile",
+      upload.array("documents"),
+      (req, res) => {
+        const files = req.files
+        if (Array.isArray(files)) {
+          res.send({
+            documents: files.map((file) => file.buffer.toString("base64")),
+            ...req.body,
+          })
+        }
+      },
+    )
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        name: "Peter",
+        documents: [
+          createReadStream("./test/fixtures/1.txt"),
+          createReadStream("./test/fixtures/2.txt"),
+          createReadStream("./test/fixtures/3.txt"),
+        ],
+      })
+      .run()
+
+    expect(body).toEqual({
+      name: "Peter",
+      documents: ["MQo=", "Mgo=", "Mwo="],
+    })
+  })
+
+  it("supports nested fields", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post("/profile", upload.none(), (req, res) => {
+      res.send({
+        ...req.body,
+      })
+    })
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        name: "Peter",
+        paymentInfo: {
+          clientId: "0x12345",
+          amount: 10,
+        },
+      })
+      .run()
+
+    expect(body).toEqual({
+      name: "Peter",
+      paymentInfo: {
+        clientId: "0x12345",
+        amount: "10",
+      },
+    })
+  })
+
+  it("skips undefined values", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post("/profile", upload.none(), (req, res) => {
+      res.send({
+        ...req.body,
+      })
+    })
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        name: "Peter",
+        paymentInfo: undefined,
+      })
+      .run()
+
+    expect(body).toEqual({
+      name: "Peter",
+    })
+  })
+
+  it("supports sending arrays", async () => {
+    const upload = multer({ storage: multer.memoryStorage() })
+    const app = express().post("/profile", upload.none(), (req, res) => {
+      res.send({
+        ...req.body,
+      })
+    })
+
+    const { body } = await tepper(app)
+      .post("/profile")
+      .sendForm({
+        friends: ["friend1", "friend2"],
+      })
+      .run()
+
+    expect(body).toEqual({
+      friends: ["friend1", "friend2"],
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for adding custom headers with the following API:

```js
await tepper(app)
  .get("/")
  .withHeaders({
    "X-Custom-Header": "custom-header-value",
  })
  .run()
```

