### PR TITLE
task: added support for cookies in request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@typescript-eslint/eslint-plugin": "5.30.4",
         "@typescript-eslint/parser": "5.30.4",
         "babel-jest": "28.1.2",
+        "cookie-parser": "^1.4.6",
         "eslint": "8.19.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
@@ -2812,6 +2813,28 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -10307,6 +10330,24 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dev": true,
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-transform-modules-commonjs": "7.18.6",
         "@babel/preset-typescript": "7.18.6",
+        "@types/cookie-parser": "^1.4.3",
         "@types/express": "4.17.13",
         "@types/jest": "28.1.4",
         "@types/mime-types": "2.1.1",
@@ -28,7 +29,7 @@
         "@typescript-eslint/eslint-plugin": "5.30.4",
         "@typescript-eslint/parser": "5.30.4",
         "babel-jest": "28.1.2",
-        "cookie-parser": "^1.4.6",
+        "cookie-parser": "1.4.6",
         "eslint": "8.19.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
@@ -1639,6 +1640,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/express": {
@@ -9445,6 +9455,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/express": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-transform-modules-commonjs": "7.18.6",
     "@babel/preset-typescript": "7.18.6",
+    "@types/cookie-parser": "^1.4.3",
     "@types/express": "4.17.13",
     "@types/jest": "28.1.4",
     "@types/mime-types": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/eslint-plugin": "5.30.4",
     "@typescript-eslint/parser": "5.30.4",
     "babel-jest": "28.1.2",
+    "cookie-parser": "1.4.6",
     "eslint": "8.19.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
@@ -67,10 +68,10 @@
     }
   },
   "dependencies": {
+    "@types/node-fetch": "2.6.2",
     "form-data-encoder": "^1.7.1",
     "formdata-node": "^4.3.2",
     "mime-types": "^2.1.34",
-    "node-fetch": "^2.6.1",
-    "@types/node-fetch": "2.6.2"
+    "node-fetch": "^2.6.1"
   }
 }

--- a/src/TepperBuilder.ts
+++ b/src/TepperBuilder.ts
@@ -100,6 +100,13 @@ export class TepperBuilder {
     })
   }
 
+  public withCookies(cookies: Record<string, string>) {
+    return new TepperBuilder(this.baseUrlServerOrExpress, {
+      ...this.config,
+      cookies,
+    })
+  }
+
   public debug({ body = true }: Partial<DebugOptions> = {}) {
     return new TepperBuilder(this.baseUrlServerOrExpress, {
       ...this.config,

--- a/src/TepperConfig.ts
+++ b/src/TepperConfig.ts
@@ -17,4 +17,5 @@ export type TepperConfig = {
   readonly jwt: string | null
   readonly debug: Partial<DebugOptions> | null
   readonly customHeaders: Record<string, string>
+  readonly cookies: Record<string, string>
 }

--- a/src/TepperRunner.ts
+++ b/src/TepperRunner.ts
@@ -1,10 +1,8 @@
 import { Express } from "express"
 import { Server } from "http"
 import fetch from "node-fetch"
-import qs from "querystring"
 import { Readable } from "stream"
 import { FormDataEncoder } from "form-data-encoder"
-import { URLSearchParams } from "url"
 import { listenAppPromised, listenServerPromised } from "./utils/listenPromised"
 import { getBaseUrl } from "./utils/getBaseUrl"
 import { closePromised } from "./utils/closePromised"
@@ -69,6 +67,8 @@ export class TepperRunner {
 
     const { body, headers } = this.insertBodyIfPresent(config)
 
+    const cookies = this.parseCookies(config.cookies)
+
     const response = await fetch(endpointWithQuery, {
       method: config.method,
       ...(body ? { body } : {}),
@@ -76,6 +76,7 @@ export class TepperRunner {
         ...headers,
         ...(config.jwt ? { Authorization: `Bearer ${config.jwt}` } : {}),
         ...config.customHeaders,
+        cookie: cookies,
       },
       redirect: "manual",
       ...(config.timeout ? { timeout: config.timeout } : {}),
@@ -146,6 +147,12 @@ export class TepperRunner {
     }
 
     return { body, headers: {} }
+  }
+
+  private static parseCookies(cookies: Record<string, string>): string {
+    return Object.keys(cookies)
+      .map((key) => `${key}=${cookies[key]}`)
+      .join("; ")
   }
 
   private static runExpectations(result: TepperResult, config: TepperConfig) {

--- a/src/tepper.ts
+++ b/src/tepper.ts
@@ -15,5 +15,6 @@ export default function tepper(baseUrlExpressOrServer: BaseUrlServerOrExpress) {
     expectedStatus: null,
     debug: null,
     customHeaders: {},
+    cookies: {},
   })
 }

--- a/test/cookies.spec.ts
+++ b/test/cookies.spec.ts
@@ -1,0 +1,25 @@
+import express from "express"
+import tepper from "../src/tepper"
+import cookieParser from "cookie-parser"
+
+describe("headers", () => {
+  it("supports sending custom cookies", async () => {
+    const CUSTOM_COOKIE = "X-Custom-Cookie"
+    const CUSTOM_COOKIE_VALUE = "custom-cookie-value"
+    const app = express()
+    app.use(cookieParser())
+
+    app.get("/", (req, res) => {
+      res.send(req.cookies)
+    })
+
+    const { body } = await tepper(app)
+      .get("/")
+      .withCookies({
+        [CUSTOM_COOKIE]: CUSTOM_COOKIE_VALUE,
+      })
+      .run()
+
+    expect(body).toEqual({ [CUSTOM_COOKIE]: CUSTOM_COOKIE_VALUE })
+  })
+})


### PR DESCRIPTION
Added support to send cookies with the request:
```
const { body } = await tepper(app)
  .get("/")
  .withCookies({
    cookieName: 'My-Cookie-Value',
  })
  .run()
```