### PR TITLE
Feat/add auth with user and password

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "author": "Daniel Ramos <danielramosacosta@hotmail.com>",
   "contributors": [
     "Daniel Ramos <danielramosacosta@hotmail.com>",
-    "Aitor Alonso <aitor@aalonso.dev>"
+    "Aitor Alonso <aitor@aalonso.dev>",
+    "Aarón Pérez <aarperper@gmail.com>"
   ],
   "license": "MIT",
   "scripts": {

--- a/src/TepperBuilder.ts
+++ b/src/TepperBuilder.ts
@@ -122,6 +122,13 @@ export class TepperBuilder<ExpectedResponse, ErrorType = StandardError> {
           jwt,
         })
       },
+      withBasicAuth: (user: string, password: string) => {
+        const basicAuth = Buffer.from(user + ":" + password).toString("base64")
+        return new TepperBuilder(this.baseUrlServerOrExpress, {
+          ...this.config,
+          basicAuth,
+        })
+      },
     }
   }
 

--- a/src/TepperBuilder.ts
+++ b/src/TepperBuilder.ts
@@ -7,8 +7,8 @@ import { TepperRunner } from "./TepperRunner"
 
 type StandardError = {
   error: {
-    status: number,
-    code: string,
+    status: number
+    code: string
     message: string
   }
 }
@@ -19,43 +19,62 @@ export class TepperBuilder<ExpectedResponse, ErrorType = StandardError> {
   ) {}
 
   public get<ExpectedResponse = any, ErrorType = StandardError>(path: string) {
-    return new TepperBuilder<ExpectedResponse, ErrorType>(this.baseUrlServerOrExpress, {
-      ...this.config,
-      method: "GET",
-      path,
-    })
+    return new TepperBuilder<ExpectedResponse, ErrorType>(
+      this.baseUrlServerOrExpress,
+      {
+        ...this.config,
+        method: "GET",
+        path,
+      },
+    )
   }
 
   public post<ExpectedResponse = any, ErrorType = StandardError>(path: string) {
-    return new TepperBuilder<ExpectedResponse, ErrorType>(this.baseUrlServerOrExpress, {
-      ...this.config,
-      method: "POST",
-      path,
-    })
+    return new TepperBuilder<ExpectedResponse, ErrorType>(
+      this.baseUrlServerOrExpress,
+      {
+        ...this.config,
+        method: "POST",
+        path,
+      },
+    )
   }
 
   public put<ExpectedResponse = any, ErrorType = StandardError>(path: string) {
-    return new TepperBuilder<ExpectedResponse, ErrorType>(this.baseUrlServerOrExpress, {
-      ...this.config,
-      method: "PUT",
-      path,
-    })
+    return new TepperBuilder<ExpectedResponse, ErrorType>(
+      this.baseUrlServerOrExpress,
+      {
+        ...this.config,
+        method: "PUT",
+        path,
+      },
+    )
   }
 
-  public patch<ExpectedResponse = any, ErrorType = StandardError>(path: string) {
-    return new TepperBuilder<ExpectedResponse, ErrorType>(this.baseUrlServerOrExpress, {
-      ...this.config,
-      method: "PATCH",
-      path,
-    })
+  public patch<ExpectedResponse = any, ErrorType = StandardError>(
+    path: string,
+  ) {
+    return new TepperBuilder<ExpectedResponse, ErrorType>(
+      this.baseUrlServerOrExpress,
+      {
+        ...this.config,
+        method: "PATCH",
+        path,
+      },
+    )
   }
 
-  public delete<ExpectedResponse = any, ErrorType = StandardError>(path: string) {
-    return new TepperBuilder<ExpectedResponse, ErrorType>(this.baseUrlServerOrExpress, {
-      ...this.config,
-      method: "DELETE",
-      path,
-    })
+  public delete<ExpectedResponse = any, ErrorType = StandardError>(
+    path: string,
+  ) {
+    return new TepperBuilder<ExpectedResponse, ErrorType>(
+      this.baseUrlServerOrExpress,
+      {
+        ...this.config,
+        method: "DELETE",
+        path,
+      },
+    )
   }
 
   public send(body: string | object) {
@@ -87,11 +106,23 @@ export class TepperBuilder<ExpectedResponse, ErrorType = StandardError> {
     })
   }
 
+  /** @deprecated Please, use __.auth()__ instead */
   public authWith(jwt: string) {
     return new TepperBuilder(this.baseUrlServerOrExpress, {
       ...this.config,
       jwt,
     })
+  }
+
+  public auth() {
+    return {
+      withBearer: (jwt: string) => {
+        return new TepperBuilder(this.baseUrlServerOrExpress, {
+          ...this.config,
+          jwt,
+        })
+      },
+    }
   }
 
   public withQuery(query: ParsedUrlQueryInput) {

--- a/src/TepperConfig.ts
+++ b/src/TepperConfig.ts
@@ -15,6 +15,7 @@ export type TepperConfig = {
     | null
   readonly timeout: number | null
   readonly jwt: string | null
+  readonly basicAuth: string | null
   readonly debug: Partial<DebugOptions> | null
   readonly customHeaders: Record<string, string>
   readonly cookies: Record<string, string>

--- a/src/TepperRunner.ts
+++ b/src/TepperRunner.ts
@@ -74,6 +74,9 @@ export class TepperRunner {
       headers: {
         ...headers,
         ...(config.jwt ? { Authorization: `Bearer ${config.jwt}` } : {}),
+        ...(config.basicAuth
+          ? { Authorization: `Basic ${config.basicAuth}` }
+          : {}),
         ...config.customHeaders,
         cookie: cookies,
       },

--- a/src/tepper.ts
+++ b/src/tepper.ts
@@ -11,6 +11,7 @@ export default function tepper(baseUrlExpressOrServer: BaseUrlServerOrExpress) {
     redirects: 0,
     timeout: null,
     jwt: null,
+    basicAuth: null,
     expectedBody: null,
     expectedStatus: null,
     debug: null,

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -35,30 +35,13 @@ describe("auth", () => {
         const expectedHeader = `Basic ${Buffer.from(
           registeredUser + ":" + userPassword,
         ).toString("base64")}`
-        const app = express()
-          .use((req, res, next) => {
-            const auth = { user: registeredUser, password: userPassword }
-            const b64auth =
-              (req.headers.authorization || "").split(" ")[1] || ""
-            const [login, password] = Buffer.from(b64auth, "base64")
-              .toString()
-              .split(":")
-            if (
-              login &&
-              password &&
-              login === auth.user &&
-              password === auth.password
-            ) {
-              return next()
-            }
-          })
-          .get("/", (req, res) => {
-            res.send(req.headers.authorization)
-          })
+        const app = express().get("/", (req, res) => {
+          res.send(req.headers.authorization)
+        })
 
         const { text } = await tepper(app)
           .auth()
-          .withBasicAuth("user", "password")
+          .withBasicAuth(registeredUser, userPassword)
           .get("/")
           .run()
 

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -28,6 +28,42 @@ describe("auth", () => {
 
         expect(text).toEqual(`Bearer ${jwt}`)
       })
+
+      it("authenticates with user and password", async () => {
+        const registeredUser = "user"
+        const userPassword = "password"
+        const expectedHeader = `Basic ${Buffer.from(
+          registeredUser + ":" + userPassword,
+        ).toString("base64")}`
+        const app = express()
+          .use((req, res, next) => {
+            const auth = { user: registeredUser, password: userPassword }
+            const b64auth =
+              (req.headers.authorization || "").split(" ")[1] || ""
+            const [login, password] = Buffer.from(b64auth, "base64")
+              .toString()
+              .split(":")
+            if (
+              login &&
+              password &&
+              login === auth.user &&
+              password === auth.password
+            ) {
+              return next()
+            }
+          })
+          .get("/", (req, res) => {
+            res.send(req.headers.authorization)
+          })
+
+        const { text } = await tepper(app)
+          .auth()
+          .withBasicAuth("user", "password")
+          .get("/")
+          .run()
+
+        expect(text).toEqual(expectedHeader)
+      })
     })
   })
 })

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -2,16 +2,32 @@ import express from "express"
 import tepper from "../src/tepper"
 
 describe("auth", () => {
-  it("sends configured jwt", async () => {
-    const app = express().get("/", (req, res) => {
-      res.send(req.headers.authorization)
+  describe("deprecated symbol", () => {
+    it("sends configured jwt", async () => {
+      const app = express().get("/", (req, res) => {
+        res.send(req.headers.authorization)
+      })
+
+      const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+      const { text } = await tepper(app).authWith(jwt).get("/").run()
+
+      expect(text).toEqual(`Bearer ${jwt}`)
     })
+    describe("new proposal", () => {
+      it("sends configured jwt as Bearer token", async () => {
+        const app = express().get("/", (req, res) => {
+          res.send(req.headers.authorization)
+        })
 
-    const jwt =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        const jwt =
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
-    const { text } = await tepper(app).authWith(jwt).get("/").run()
+        const { text } = await tepper(app).auth().withBearer(jwt).get("/").run()
 
-    expect(text).toEqual(`Bearer ${jwt}`)
+        expect(text).toEqual(`Bearer ${jwt}`)
+      })
+    })
   })
 })


### PR DESCRIPTION
- Changes method for auth for a generic one
- Deprecates old JWT auth method
- Adds basic auth support

New proposed API for auth:
```typescript
await tepper(app)
          .auth()
          .withBasicAuth(user, password)
          .get("/")
          .run()

await tepper(app)
         .auth()
         .withBearer(jwt)
         .get("/")
         .run()
```

@DanielRamosAcosta  Are we happy with this API for auth?
I also thought about:
```typescript
await tepper(app)
          .authWithBasicAuth(user, password)
          .get("/")
          .run()

await tepper(app)
          .authWithBearer(jwt)
          .get("/")
          .run()
```

But I think that the current `.authWith()` should be renamed, thus breaking the current API. What do yout think?