### PR TITLE
fix: node 18 address names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tepper",
-  "version": "0.4.3",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tepper",
-      "version": "0.4.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tepper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Modern library for testing HTTP servers",
   "main": "dist/tepper.js",
   "homepage": "https://github.com/DanielRamosAcosta/tepper",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "Modern library for testing HTTP servers",
   "main": "dist/tepper.js",
-  "engines": {
-    "node": ">= 12.13.0"
-  },
   "homepage": "https://github.com/DanielRamosAcosta/tepper",
   "repository": "https://github.com/DanielRamosAcosta/tepper",
   "author": "Daniel Ramos <danielramosacosta@hotmail.com>",

--- a/src/utils/getBaseUrl.ts
+++ b/src/utils/getBaseUrl.ts
@@ -18,5 +18,9 @@ export function getBaseUrl(server: Server) {
     throw new Error(`Address is not an object`)
   }
 
-  return `http://${addressInfo.address}:${addressInfo.port}`
+  const hostname = addressInfo.address.startsWith("::")
+    ? "127.0.0.1"
+    : addressInfo.address
+
+  return `http://${hostname}:${addressInfo.port}`
 }

--- a/test/server-setup.spec.ts
+++ b/test/server-setup.spec.ts
@@ -63,7 +63,7 @@ describe("server setup", () => {
     const app = express().get("/", (_req, res) => {
       res.send("hey")
     })
-    const server = await listenAppPromised(app, 4001, "127.0.0.1")
+    const server = await listenAppPromised(app, 4001, "localhost")
 
     const { text, status } = await tepper(`http://localhost:4001`)
       .get("/")
@@ -79,7 +79,7 @@ describe("server setup", () => {
     const app = express().get("/hello", (_req, res) => {
       res.send("hey")
     })
-    const server = await listenAppPromised(app, 4001, "127.0.0.1")
+    const server = await listenAppPromised(app, 4001, "localhost")
 
     const { text, status } = await tepper(`http://localhost:4001`)
       .get("/hello")


### PR DESCRIPTION
Tepper relied on `server.address()` returning always the host name, but seems that this has changed and now returns `::1` or `::`