### PR TITLE
feature: use native assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Modern library for testing HTTP servers",
   "main": "dist/tepper.js",
   "engines": {
-    "node": ">= 12.13.0"
+    "node": ">= 14"
   },
   "homepage": "https://github.com/DanielRamosAcosta/tepper",
   "repository": "https://github.com/DanielRamosAcosta/tepper",

--- a/src/tepper.ts
+++ b/src/tepper.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from "node:assert/strict"
 import { BaseUrlServerOrExpress } from "./BaseUrlServerOrExpress"
 import { TepperBuilder } from "./TepperBuilder"
 import { TepperConfig } from "./TepperConfig"
@@ -21,9 +22,7 @@ export default function tepper(
     customHeaders: {},
     cookies: {},
     expectToEqual: (a, b) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      globalThis.expect(a).toEqual(b)
+      assert.deepStrictEqual(a, b)
     },
     ...config,
   })

--- a/src/tepper.ts
+++ b/src/tepper.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from "node:assert/strict"
+import assert from "assert"
 import { BaseUrlServerOrExpress } from "./BaseUrlServerOrExpress"
 import { TepperBuilder } from "./TepperBuilder"
 import { TepperConfig } from "./TepperConfig"
@@ -22,7 +22,7 @@ export default function tepper(
     customHeaders: {},
     cookies: {},
     expectToEqual: (a, b) => {
-      assert.deepStrictEqual(a, b)
+      assert.strict.deepStrictEqual(a, b)
     },
     ...config,
   })

--- a/test/edge-cases.spec.ts
+++ b/test/edge-cases.spec.ts
@@ -1,7 +1,6 @@
 import { it, expect, describe } from "vitest"
 import express from "express"
 import tepper from "../src/tepper"
-import { expectToEqual } from "./utils/expectToEqual"
 
 describe("edge cases", () => {
   it("should work when unbuffered", async () => {
@@ -9,7 +8,7 @@ describe("edge cases", () => {
       res.end("Hello")
     })
 
-    await tepper(app, { expectToEqual }).get("/").expect("Hello").run()
+    await tepper(app).get("/").expect("Hello").run()
   })
 
   it("should handle socket errors", async () => {

--- a/test/http-verbs.spec.ts
+++ b/test/http-verbs.spec.ts
@@ -1,7 +1,6 @@
 import { it, describe } from "vitest"
 import express from "express"
 import tepper from "../src/tepper"
-import { expectToEqual } from "./utils/expectToEqual"
 
 const httpVerbs = [["get"], ["post"], ["put"], ["patch"], ["delete"]] as const
 
@@ -13,6 +12,6 @@ describe("http verbs", () => {
       res.send()
     })
 
-    await tepper(app, { expectToEqual })[verb]("/").expect(200).run()
+    await tepper(app)[verb]("/").expect(200).run()
   })
 })

--- a/test/sending-json.spec.ts
+++ b/test/sending-json.spec.ts
@@ -1,7 +1,6 @@
 import { it, describe } from "vitest"
 import express from "express"
 import tepper from "../src/tepper"
-import { expectToEqual } from "./utils/expectToEqual"
 
 describe("sending JSON", () => {
   it("should work with .send()", async () => {
@@ -11,11 +10,7 @@ describe("sending JSON", () => {
         res.send(req.body.name)
       })
 
-    await tepper(app, { expectToEqual })
-      .post("/")
-      .send({ name: "john" })
-      .expect("john")
-      .run()
+    await tepper(app).post("/").send({ name: "john" }).expect("john").run()
   })
 
   it("should work with .send() with an array", async () => {
@@ -25,10 +20,6 @@ describe("sending JSON", () => {
         res.send(req.body)
       })
 
-    await tepper(app, { expectToEqual })
-      .post("/")
-      .send([1, 2, 3])
-      .expect([1, 2, 3])
-      .run()
+    await tepper(app).post("/").send([1, 2, 3]).expect([1, 2, 3]).run()
   })
 })

--- a/test/utils/expectToEqual.ts
+++ b/test/utils/expectToEqual.ts
@@ -1,5 +1,0 @@
-import { expect } from "vitest"
-
-export function expectToEqual(a: unknown, b: unknown) {
-  expect(a).toEqual(b)
-}


### PR DESCRIPTION
This PR uses the native `node:assert/strict`, instead of jest implementation, which makes this library framework-agnostic